### PR TITLE
Composer.json tweaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "10up/wp-content-connect",
     "description": "Post to Post and Post to User Library for WordPress",
-    "type": "wordpress-library",
+    "type": "wordpress-plugin",
     "license": "GPL-3.0-or-later",
     "authors": [
         {
@@ -10,7 +10,9 @@
         }
     ],
     "minimum-stability": "dev",
-    "require": {},
+    "require": {
+        "composer/installers": "^1.2"
+    },
     "autoload": {
         "psr-4": {
             "TenUp\\ContentConnect\\": "includes",


### PR DESCRIPTION
When trying to pull this into a project via Composer. The plugin was always being installed in 10up/wp-content-connect. This change to addresses that to allow it to be added correctly using the `wordpress-plugin` type/