### PR TITLE
extend actions to include which types of relationships are getting modified

### DIFF
--- a/includes/Relationships/PostToPost.php
+++ b/includes/Relationships/PostToPost.php
@@ -134,7 +134,16 @@ class PostToPost extends Relationship {
 			array( '%d', '%d', '%s' )
 		);
 
-		do_action( 'tenup-content-connect-add-relationship', $pid1, $pid2, $this->name );
+		/**
+		 * Fires after a relationship has been added
+		 * @since 1.3.0
+		 *
+		 * @param int $pid1 ID of the first item
+		 * @param int $pid2 ID of the second item
+		 * @param string $name relationship name
+		 * @param string $type relationship type (post-to-post|post-to-user)
+		 */
+		do_action( 'tenup-content-connect-add-relationship', $pid1, $pid2, $this->name, 'post-to-post' );
 	}
 
 	public function delete_relationship( $pid1, $pid2 ) {
@@ -150,7 +159,16 @@ class PostToPost extends Relationship {
 			array( '%d', '%d', '%s' )
 		);
 
-		do_action( 'tenup-content-connect-delete-relationship', $pid1, $pid2, $this->name );
+		/**
+		 * Fires after a relationship has been deleted
+		 * @since 1.3.0
+		 *
+		 * @param int $pid1 ID of the first item
+		 * @param int $pid2 ID of the second item
+		 * @param string $name relationship name
+		 * @param string $type relationship type (post-to-post|post-to-user)
+		 */
+		do_action( 'tenup-content-connect-delete-relationship', $pid1, $pid2, $this->name, 'post-to-post' );
 	}
 
 	/**
@@ -175,7 +193,15 @@ class PostToPost extends Relationship {
 			$this->add_relationship( $post_id, $add );
 		}
 
-		do_action( 'tenup-content-connect-replace-relationships', $post_id, $related_ids );
+		/**
+		 * Fires after a relationship has been replaced
+		 * @since 1.3.0
+		 *
+		 * @param int $pid1 ID of the first item
+		 * @param int $pid2 ID of the second item
+		 * @param string $type relationship type (post-to-post|post-to-user|user-to-post)
+		 */
+		do_action( 'tenup-content-connect-replace-relationships', $post_id, $related_ids, 'post-to-post' );
 	}
 
 	/**

--- a/includes/Relationships/PostToUser.php
+++ b/includes/Relationships/PostToUser.php
@@ -106,6 +106,11 @@ class PostToUser extends Relationship {
 			array( 'post_id' => $post_id, 'user_id' => $user_id, 'name' => $this->name ),
 			array( '%d', '%d', '%s' )
 		);
+
+		/**
+		 * This action is documented in PostToPost.php
+		 */
+		do_action( 'tenup-content-connect-add-relationship', $post_id, $user_id, $this->name, 'post-to-user' );
 	}
 
 	/**
@@ -122,6 +127,11 @@ class PostToUser extends Relationship {
 			array( 'post_id' => $post_id, 'user_id' => $user_id, 'name' => $this->name ),
 			array( '%d', '%d', '%s' )
 		);
+
+		/**
+		 * This action is documented in PostToPost.php
+		 */
+		do_action( 'tenup-content-connect-delete-relationship', $post_id, $user_id, $this->name, 'post-to-user' );
 	}
 
 	/**
@@ -145,6 +155,11 @@ class PostToUser extends Relationship {
 		foreach( $add_user_ids as $add_user_id ) {
 			$this->add_relationship( $post_id, $add_user_id );
 		}
+
+		/**
+		 * This action is documented in PostToPost.php
+		 */
+		do_action( 'tenup-content-connect-replace-relationships', $post_id, $user_ids, 'post-to-user' );
 	}
 
 	/**
@@ -168,6 +183,11 @@ class PostToUser extends Relationship {
 		foreach( $add_post_ids as $add_post_id ) {
 			$this->add_relationship( $add_post_id, $user_id );
 		}
+
+		/**
+		 * This action is documented in PostToPost.php
+		 */
+		do_action( 'tenup-content-connect-replace-relationships', $user_id, $post_ids, 'user-to-post' );
 	}
 
 	/**


### PR DESCRIPTION
This expands on https://github.com/10up/wp-content-connect/pull/32 to include the same hooks to Post To User relations, adding contextual information. Also documents the hooks.