### PR TITLE
fix: document `PostToPost::to` as an array

### DIFF
--- a/includes/Relationships/PostToPost.php
+++ b/includes/Relationships/PostToPost.php
@@ -16,7 +16,7 @@ class PostToPost extends Relationship {
 	/**
 	 * CPT Name of the second post type in the relationship
 	 *
-	 * @var string
+	 * @var array
 	 */
 	public $to;
 


### PR DESCRIPTION
### Description of the Change

Changes the PHPDoc on `PostToPost::to` from `string` to `array`, so that it accurately reflects [the data stored there](https://github.com/10up/wp-content-connect/blob/f0068b2c79b8b945e19fe2153c8b274a435e68c1/includes/Relationships/PostToPost.php#L42), which fixes warnings where an IDE thinks things like [`count()` are being run against a `string`](https://github.com/10up/wp-content-connect/blob/f0068b2c79b8b945e19fe2153c8b274a435e68c1/includes/Relationships/PostToPost.php#L65) when they're not.

### Benefits

Better developer experience.

### Possible Drawbacks

None that I'm aware of.

### Verification Process

- I changed the PHPDoc from string to array and verified that my IDE no longer complains about `count()` being used with an improper data type. 

No functional changes.


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- Enter any applicable Issues here -->

### Changelog Entry
Fixed PHPDoc for `PostToPost::to` property.

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
