### PR TITLE
Feature/multiple posttype UI

### DIFF
--- a/includes/Registry.php
+++ b/includes/Registry.php
@@ -35,7 +35,7 @@ class Registry {
 		sort( $to );
 		$to = implode( '.', $to );
 
-		return "{$from}_{$to}_{$name}";
+		return "{$from}~{$to}~{$name}";
 	}
 
 	/**
@@ -70,6 +70,20 @@ class Registry {
 			return $this->post_post_relationships[ $key ];
 		}
 
+		// Fuzzy match the relationship by parsing the key and looping through the relationships
+		foreach ( $this->post_post_relationships as $relationship_key => $relationship ) {
+			$relationship_key_parts = explode( '~', $relationship_key );
+			$key_parts = explode( '~', $key );
+
+			if (
+				$key_parts[0] === $relationship_key_parts[0] &&
+				strpos( $relationship_key_parts[1], $key_parts[1] ) !== false &&
+				$key_parts[2] === $relationship_key_parts[2]
+			) {
+				return $this->post_post_relationships[ $relationship_key ];
+			}
+		}
+
 		return false;
 	}
 
@@ -91,10 +105,6 @@ class Registry {
 			return $relationship;
 		}
 
-		// Try the inverse, only if "cpt2" isn't an array
-		if ( is_array( $cpt2 ) ) {
-			return false;
-		}
 		$key = $this->get_relationship_key( $cpt2, $cpt1, $name );
 
 		$relationship = $this->get_post_to_post_relationship_by_key( $key );

--- a/includes/Relationships/PostToPost.php
+++ b/includes/Relationships/PostToPost.php
@@ -61,13 +61,9 @@ class PostToPost extends Relationship {
 
 		// Make sure CPT is not the same as "from" so we don't get a duplicate, then register if enabled
 		if ( $this->to !== $this->from && $this->enable_to_ui === true ) {
-			// Currently, only support a default UI when the "to" end is a single post type
-			if ( count( $this->to ) === 1 ) {
-				$this->to_ui = new \TenUp\ContentConnect\UI\PostToPost( $this, $this->to[0], $this->to_labels, $this->to_sortable );
-				$this->to_ui->setup();
-			}
+			$this->to_ui = new \TenUp\ContentConnect\UI\PostToPost( $this, $this->to, $this->to_labels, $this->to_sortable );
+			$this->to_ui->setup();
 		}
-
 	}
 
 	/**

--- a/includes/UI/MetaBox.php
+++ b/includes/UI/MetaBox.php
@@ -72,7 +72,7 @@ class MetaBox {
 			$post_type = get_post_type( $post_id );
 			if ( $relationship->from_ui->render_post_type === $post_type ) {
 				$relationship->from_ui->handle_save( $relationship_data, $post_id );
-			} else if ( is_object( $relationship->to_ui ) && $relationship->to_ui->render_post_type === $post_type ) {
+			} else if ( is_object( $relationship->to_ui ) && in_array( $post_type, $relationship->to_ui->render_post_type, true ) ) {
 				$relationship->to_ui->handle_save( $relationship_data, $post_id );
 			}
 

--- a/includes/UI/PostToPost.php
+++ b/includes/UI/PostToPost.php
@@ -11,13 +11,22 @@ class PostToPost extends PostUI {
 	}
 
 	public function filter_data( $data, $post ) {
+
+		if ( ! is_array( $this->render_post_type ) ) {
+			$this->render_post_type = array( $this->render_post_type );
+		}
+
 		// Don't add any data if we aren't on the post type we're supposed to render for
-		if ( $post->post_type !== $this->render_post_type ) {
+		if ( ! in_array( $post->post_type, $this->render_post_type ) ) {
 			return $data;
 		}
 
 		// Determine the other post type in the relationship
-		$other_post_type = $this->relationship->from == $this->render_post_type ? $this->relationship->to : $this->relationship->from;
+		if ( $post->post_type === $this->relationship->from ) {
+			$other_post_type = $this->relationship->to;
+		} else {
+			$other_post_type = $this->relationship->from;
+		}
 
 		$final_posts = array();
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This update adds support for the UI metabox to display on editor screens for post_to_post connections which have a "one to many" relationship.

The plugin supports the ability to define a "one to many" relationship, however it also intentionally disables the metabox from displaying within the editor. I am unclear why this was disabled originally, but it seems the architecture does not easily support the feature because of how relationship keys are detected and constructed.

This PR removes these restrictions and adds a "fuzzy match" to try and better identify the post relationships.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/wp-content-connect/issues/103

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Create a "one to many" relationship using [define_post_to_post](https://github.com/10up/wp-content-connect?tab=readme-ov-file#define_post_to_post-from-to-name-args--array-). The `$to` value should be an array of post types.

Once defined, ensure:
 * The UI to be visible on all relevant post types
 * The values are update-able
  * Queries to correctly display their relevant connections work as expected

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
> Developer - Non-functional update

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
