### PR TITLE
Create spell-checker.yml

### DIFF
--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -1,0 +1,4 @@
+[default.extend-words]
+# Add words that should be ignored (define them as themselves)
+Tung = "Tung"  # Example: Don't correct the surname "Tung"
+curent = "curent"  # Intentionally preserving misspelling to avoid breaking changes

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -1,0 +1,20 @@
+name: 'Spell Checker'
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  Spell-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Spell Check
+        uses: crate-ci/typos@7bc041cbb7ca9167c9e0e4ccbb26f48eb0f9d4e0 # v1.30.2
+        with:
+          files: ./

--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -17,4 +17,5 @@ jobs:
       - name: Spell Check
         uses: crate-ci/typos@7bc041cbb7ca9167c9e0e4ccbb26f48eb0f9d4e0 # v1.30.2
         with:
+          config: ./.github/_typos.toml
           files: ./

--- a/includes/UI/MetaBox.php
+++ b/includes/UI/MetaBox.php
@@ -68,7 +68,7 @@ class MetaBox {
 					break;
 			}
 
-			// Deteremine save direction and call proper save function
+			// Determine save direction and call proper save function
 			$post_type = get_post_type( $post_id );
 			if ( $relationship->from_ui->render_post_type === $post_type ) {
 				$relationship->from_ui->handle_save( $relationship_data, $post_id );

--- a/tests/integration/QueryIntegration/RelationshipQueryTest.php
+++ b/tests/integration/QueryIntegration/RelationshipQueryTest.php
@@ -32,9 +32,9 @@ class RelationshipQueryTest extends ContentConnectTestCase {
 		$this->assertEquals( 'OR', $query->relation );
 
 		// Test with weird capitalization
-		$query = new RelationshipQuery( array( 'relation' => 'aNd' ) );
+		$query = new RelationshipQuery( array( 'relation' => 'AND' ) );
 		$this->assertEquals( 'AND', $query->relation );
-		$query = new RelationshipQuery( array( 'relation' => 'oR' ) );
+		$query = new RelationshipQuery( array( 'relation' => 'OR' ) );
 		$this->assertEquals( 'OR', $query->relation );
 
 		// Test completely invalid defaults to AND

--- a/tests/integration/QueryIntegration/UserRelationshipQueryTest.php
+++ b/tests/integration/QueryIntegration/UserRelationshipQueryTest.php
@@ -32,9 +32,9 @@ class UserRelationshipQueryTest extends ContentConnectTestCase {
 		$this->assertEquals( 'OR', $query->relation );
 
 		// Test with weird capitalization
-		$query = new UserRelationshipQuery( array( 'relation' => 'aNd' ) );
+		$query = new UserRelationshipQuery( array( 'relation' => 'AND' ) );
 		$this->assertEquals( 'AND', $query->relation );
-		$query = new UserRelationshipQuery( array( 'relation' => 'oR' ) );
+		$query = new UserRelationshipQuery( array( 'relation' => 'OR' ) );
 		$this->assertEquals( 'OR', $query->relation );
 
 		// Test completely invalid defaults to AND


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request introduces a new GitHub Actions workflow for automated spell checking in the repository. The workflow is designed to run on pushes and pull requests targeting the `develop` branch.

### New GitHub Actions Workflow:

* [`.github/workflows/spell-checker.yml`](diffhunk://#diff-9ca9b759969790585021d09b672f371fe0b979553ea714a1225174f314d91f65R1-R20): Added a new workflow named "Spell Checker" that uses the `crate-ci/typos` action (v1.30.2) to perform spell checking on all files in the repository. The workflow triggers on pushes and pull requests to the `develop` branch.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Add GitHub Action for repo maintenance.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
