### PR TITLE
Add/gha plugin zip and check

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -1,0 +1,62 @@
+name: Build release zip
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build_zip:
+    name: Build release zip
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Setup node
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+      with:
+        cache: 'npm'
+        node-version-file: .nvmrc
+
+    - name: Cache node_modules
+      id: cache-node-modules
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache dependencies
+      id: cache-composer
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      env:
+        cache-name: cache-composer
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.lock') }}
+
+    - name: Install node dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: npm ci --no-optional
+
+    - name: Install composer dependencies
+      run: composer install --no-dev -o
+
+    - name: Build
+      run: |
+        npm run build
+        npm run makepot
+        npm run archive
+
+    - name: Upload the ZIP file as an artifact
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      with:
+        name: ${{ github.event.repository.name }}
+        path: release
+        retention-days: 2

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,41 @@
+name: WordPress Plugin Checks
+
+on:
+  push:
+    branches:
+      - develop
+      - trunk
+      - master
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    uses: 10up/wp-content-connect/.github/workflows/build-release-zip.yml@develop
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download built zip
+        uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # v4.2.0
+        with:
+          name: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ${{ github.event.repository.name }}
+
+      - name: Run plugin check
+        uses: wordpress/plugin-check-action@70f38272b2beee386e973f319591baa2fc7dff16 # v1.1.2
+        with:
+          build-dir: ${{ github.event.repository.name }}
+          exclude-checks: 'plugin_readme,plugin_updater' # Plugin isn't on .org so excluding these for now.
+          exclude-directories: 'assets,dist,vendor'
+          ignore-warnings: true


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request introduces two new GitHub Actions workflows to streamline the build and testing processes for a WordPress plugin. The first workflow generates a release ZIP file, while the second performs automated plugin checks. Below is a summary of the key changes:

### New GitHub Actions Workflows

* **Build Release ZIP Workflow**:
  - Added `.github/workflows/build-release-zip.yml` to automate the creation of a release ZIP file. This includes steps for caching dependencies, installing Node.js and Composer packages, building the project, and uploading the ZIP file as an artifact.

* **WordPress Plugin Checks Workflow**:
  - Added `.github/workflows/plugin-check.yml` to perform automated checks on the plugin. This workflow triggers on specific branches and pull requests, reuses the build workflow, and runs a plugin check using the `wordpress/plugin-check-action`.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Add GitHub Actions for repo maintenance.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
