### PR TITLE
Add support for max_items

### DIFF
--- a/includes/API/V2/Route/Relationships.php
+++ b/includes/API/V2/Route/Relationships.php
@@ -80,6 +80,7 @@ class Relationships extends AbstractRoute {
 					$prepared_relationships[ $rel_key ]['object_type'] = 'user';
 					$prepared_relationships[ $rel_key ]['labels']      = $relationship->from_labels;
 					$prepared_relationships[ $rel_key ]['sortable']    = $relationship->from_sortable;
+					$prepared_relationships[ $rel_key ]['max_items']   = $relationship->from_max_items;
 					$prepared_relationships[ $rel_key ]['enable_ui']   = $relationship->enable_from_ui;
 					break;
 

--- a/includes/API/V2/Route/Relationships.php
+++ b/includes/API/V2/Route/Relationships.php
@@ -88,12 +88,14 @@ class Relationships extends AbstractRoute {
 					$prepared_relationships[ $rel_key ]['from']        = array(
 						'object_type' => $relationship->from,
 						'labels'      => $relationship->from_labels,
+						'max_items'   => $relationship->from_max_items,
 						'sortable'    => $relationship->from_sortable,
 						'enable_ui'   => $relationship->enable_from_ui,
 					);
 					$prepared_relationships[ $rel_key ]['to']          = array(
 						'object_type' => $relationship->to,
 						'labels'      => $relationship->to_labels,
+						'max_items'   => $relationship->to_max_items,
 						'sortable'    => $relationship->to_sortable,
 						'enable_ui'   => $relationship->enable_to_ui,
 					);

--- a/includes/API/V2/Route/Relationships.php
+++ b/includes/API/V2/Route/Relationships.php
@@ -25,7 +25,7 @@ class Relationships extends AbstractRoute {
 			array(
 				'args' => array(
 					'rel_type' => array(
-						'description'       => __( 'The relationship type to filter relatioships by.', 'tenup-content-connect' ),
+						'description'       => __( 'The relationship type to filter relationships by.', 'tenup-content-connect' ),
 						'type'              => 'string',
 						'default'           => 'post-to-post',
 						'sanitize_callback' => 'sanitize_text_field',

--- a/includes/Helpers.php
+++ b/includes/Helpers.php
@@ -292,11 +292,13 @@ function get_post_to_post_relationships_data( $post, $other_post_type = false, $
 			$relationship_data['labels']    = $relationship->from_labels;
 			$relationship_data['enable_ui'] = $relationship->enable_from_ui;
 			$relationship_data['sortable']  = $relationship->from_sortable;
+			$relationship_data['max_items'] = $relationship->from_max_items;
 			$relationship_data['post_type'] = $relationship_to;
 		} else {
 			$relationship_data['labels']    = $relationship->to_labels;
 			$relationship_data['enable_ui'] = $relationship->enable_to_ui;
 			$relationship_data['sortable']  = $relationship->to_sortable;
+			$relationship_data['max_items'] = $relationship->to_max_items;
 			$relationship_data['post_type'] = array( $relationship->from );
 		}
 

--- a/includes/Helpers.php
+++ b/includes/Helpers.php
@@ -411,6 +411,7 @@ function get_post_to_user_relationships_data( $post, $context = 'view' ) {
 			'object_type' => 'user',
 			'labels'      => $relationship->from_labels,
 			'sortable'    => $relationship->from_sortable,
+			'max_items'   => $relationship->from_max_items,
 			'enable_ui'   => $relationship->enable_from_ui,
 		);
 

--- a/includes/Relationships/Relationship.php
+++ b/includes/Relationships/Relationship.php
@@ -62,12 +62,27 @@ abstract class Relationship {
 	 */
 	public $to_sortable;
 
+	/**
+	 * The max number of selectable items
+	 *
+	 * @var int
+	 */
+	public $from_max_items;
+
+	/**
+	 * The max number of selectable items
+	 *
+	 * @var int
+	 */
+	public $to_max_items;
+
 	public function __construct( $name, $args = array() ) {
 		$this->name = $name;
 
 		$defaults = array(
 			'from' => array(
 				'enable_ui' => true,
+				'max_items' => 99,
 				'sortable' => false,
 				'labels' => array(
 					'name' => $name,
@@ -75,6 +90,7 @@ abstract class Relationship {
 			),
 			'to' => array(
 				'enable_ui' => false,
+				'max_items' => 99,
 				'sortable' => false,
 				'labels' => array(
 					'name' => $name,
@@ -87,10 +103,12 @@ abstract class Relationship {
 		$this->enable_from_ui = $args['from']['enable_ui'];
 		$this->from_sortable = $args['from']['sortable'];
 		$this->from_labels = $args['from']['labels'];
+		$this->from_max_items = $args['from']['max_items'];
 
 		$this->enable_to_ui = $args['to']['enable_ui'];
 		$this->to_sortable = $args['to']['sortable'];
 		$this->to_labels = $args['to']['labels'];
+		$this->to_max_items = $args['to']['max_items'];
 	}
 
 	abstract function setup();


### PR DESCRIPTION
### Description of the Change

The JS that renders the content picker already added support for a new max_items key on the relationship args. This update adds the required PHP update to support that key.

### How to test the Change

Register a relationship using the max_items key, e.g.:

```
$args = array(
	'from' => array(
		'max_items' => 2,
		'enable_ui' => true,
		'sortable' => true,
		'labels' => array(
			'name' => 'Related Content',
		),
	),
	'to' => array(
		'max_items' => 2,
		'enable_ui' => false,
		'sortable' => true,
		'labels' => array(
			'name' => 'Related Content',
		),
	),
);
```
