### PR TITLE
Introduce tenup-content-connect-update-relationships-order action

### DIFF
--- a/includes/Relationships/PostToPost.php
+++ b/includes/Relationships/PostToPost.php
@@ -49,7 +49,7 @@ class PostToPost extends Relationship {
 		$this->from = $from;
 		$this->to = $to;
 		$this->id = strtolower( get_class( $this ) ) . "-{$name}-{$from}-" . implode( '.', $to );
-		
+
 		parent::__construct( $name, $args );
 	}
 
@@ -234,7 +234,7 @@ class PostToPost extends Relationship {
 				'order' => $order
 			);
 		}
-		
+
 		$fields = array(
 			'id1' => '%d',
 			'id2' => '%d',
@@ -252,9 +252,10 @@ class PostToPost extends Relationship {
 		 *
 		 * @param int $object_id ID of the post we're ordering on.
 		 * @param int[] $ordered_ids IDs of the posts being ordered
-		 * @param string $type relationship type (post-to-post|post-to-user)
+		 * @param string $name relationship name
+		 * @param string $type relationship type (post-to-post|post-to-user|user-to-post)
 		 */
-		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_ids, 'post-to-post' );
+		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_ids, $this->name, 'post-to-post' );
 	}
 
 }

--- a/includes/Relationships/PostToPost.php
+++ b/includes/Relationships/PostToPost.php
@@ -245,6 +245,16 @@ class PostToPost extends Relationship {
 		/** @var \TenUp\ContentConnect\Tables\PostToPost $table */
 		$table = Plugin::instance()->get_table( 'p2p' );
 		$table->replace_bulk( $fields, $data );
+
+		/**
+		 * Fires after a relationship order has been updated
+		 * @since 1.7.0
+		 *
+		 * @param int $object_id ID of the post we're ordering on.
+		 * @param int[] $ordered_ids IDs of the posts being ordered
+		 * @param string $type relationship type (post-to-post|post-to-user)
+		 */
+		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_ids, 'post-to-post' );
 	}
 
 }

--- a/includes/Relationships/PostToUser.php
+++ b/includes/Relationships/PostToUser.php
@@ -226,6 +226,11 @@ class PostToUser extends Relationship {
 		/** @var \TenUp\ContentConnect\Tables\PostToUser $table */
 		$table = Plugin::instance()->get_table( 'p2u' );
 		$table->replace_bulk( $fields, $data );
+
+		/**
+		 * This action is documented in PostToPost.php
+		 */
+		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_ids, 'post-to-user' );
 	}
 
 	/**
@@ -266,6 +271,11 @@ class PostToUser extends Relationship {
 		/** @var \TenUp\ContentConnect\Tables\PostToUser $table */
 		$table = Plugin::instance()->get_table( 'p2u' );
 		$table->replace_bulk( $fields, $data );
+
+		/**
+		 * This action is documented in PostToPost.php
+		 */
+		do_action( 'tenup-content-connect-update-relationships-order', $user_id, $ordered_post_ids, 'user-to-post' );
 	}
 
 }

--- a/includes/Relationships/PostToUser.php
+++ b/includes/Relationships/PostToUser.php
@@ -230,7 +230,7 @@ class PostToUser extends Relationship {
 		/**
 		 * This action is documented in PostToPost.php
 		 */
-		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_ids, 'post-to-user' );
+		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_ids, $this->name, 'post-to-user' );
 	}
 
 	/**
@@ -275,7 +275,7 @@ class PostToUser extends Relationship {
 		/**
 		 * This action is documented in PostToPost.php
 		 */
-		do_action( 'tenup-content-connect-update-relationships-order', $user_id, $ordered_post_ids, 'user-to-post' );
+		do_action( 'tenup-content-connect-update-relationships-order', $user_id, $ordered_post_ids, $this->name, 'user-to-post' );
 	}
 
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Introduces a new action to let extenders run logic after order has been updated.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/wp-content-connect/issues/114

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - `tenup-content-connect-update-relationships-order` action for developers.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ocean90

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
