### PR TITLE
Add WordPress Playground demo blueprint

### DIFF
--- a/.github/blueprints/blueprint.json
+++ b/.github/blueprints/blueprint.json
@@ -19,7 +19,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/10up/wp-content-connect/archive/refs/tags/2.0.0-beta.2.zip"
+        "url": "https://github.com/10up/wp-content-connect/archive/refs/heads/develop.zip"
       },
       "options": {
         "activate": true,

--- a/.github/blueprints/blueprint.json
+++ b/.github/blueprints/blueprint.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "meta": {
+    "title": "WP Content Connect",
+    "description": "WordPress library that enables direct relationships for posts to posts and posts to users.",
+    "author": "10up"
+  },
+  "landingPage": "/wp-admin/",
+  "preferredVersions": {
+    "php": "8.3",
+    "wp": "latest"
+  },
+  "features": {
+    "networking": true
+  },
+  "login": true,
+  "steps": [
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "url",
+        "url": "https://github.com/10up/wp-content-connect/archive/refs/tags/2.0.0-beta.2.zip"
+      },
+      "options": {
+        "activate": true,
+        "targetFolderName": "wp-content-connect"
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "git:directory",
+        "url": "https://github.com/fabiankaegy/wp-content-connect-example-data",
+        "ref": "main"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "wp-cli",
+      "command": "wp content-connect-example generate --universities=10 --cities=20 --people=100"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The changes below affect only code that referenced plugin **internals** that wer
 - Block Editor UI integration with automatic relationship panels in the Document Settings sidebar (props [@fabiankaegy](https://github.com/fabiankaegy), [@barryceelen](https://github.com/barryceelen), [@s3rgiosan](https://github.com/s3rgiosan) via [#94](https://github.com/10up/wp-content-connect/pull/94)).
 - WordPress JavaScript filter hooks `contentConnect.searchResultFilter`, `contentConnect.pickedItemFilter`, and `contentConnect.pickedItemPreviewComponent` for customizing the Block Editor UI, with relationship context awareness (props [@s3rgiosan](https://github.com/s3rgiosan) via [#104](https://github.com/10up/wp-content-connect/pull/104)).
 - WordPress 7.0 compatibility; set WordPress minimum supported version to 6.8 (props [@mphillips](https://github.com/mphillips) via [#120](https://github.com/10up/wp-content-connect/pull/120)).
+- WordPress Playground blueprint (`.github/blueprints/blueprint.json`) for a one-click, zero-install plugin demo (props [@s3rgiosan](https://github.com/s3rgiosan) via [#122](https://github.com/10up/wp-content-connect/pull/122)).
 
 ### Changed
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Adds a WordPress Playground blueprint (`.github/blueprints/blueprint.json`) that spins up a live, zero-install demo of WP Content Connect directly in the browser. Opening the blueprint boots a fresh WordPress instance, installs and activates the plugin, seeds example content, and drops the user straight into `wp-admin` — letting reviewers, contributors, and users try post-to-post and post-to-user relationships without a local environment.

The blueprint:

- Targets **PHP 8.3** and the **latest** WordPress release.
- Enables `networking` (required to pull the plugin ZIP and example-data repo) and auto-`login`.
- Installs **WP Content Connect** from the `develop` branch ZIP and activates it into `wp-content-connect`.
- Installs the companion **`wp-content-connect-example-data`** plugin from Git (`main`) to provide the WP-CLI seeder.
- Runs `wp content-connect-example generate --universities=10 --cities=20 --people=100` to populate demo posts and users with real relationships.
- Lands on `/wp-admin/`.

Benefits: instant, reproducible demo environment; lower barrier for evaluating the plugin; a shareable link for issues/support.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Open the blueprint in Playground, e.g. `https://playground.wordpress.net/?blueprint-url=<raw-url-to-.github/blueprints/blueprint.json>` (or via the "Preview in Playground" flow once merged).
2. Confirm WordPress boots to `/wp-admin/` already logged in, on PHP 8.3 + latest WP.
3. Confirm **WP Content Connect** and the example-data plugin both show as active under Plugins.
4. Confirm seeded content exists (universities/cities/people posts and users) and that relationship panels render on those posts.
5. Verify the blueprint validates against the schema (`$schema` resolves, no console errors in the Playground boot log).

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - Add a WordPress Playground blueprint for a one-click, zero-install plugin demo.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @s3rgiosan

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
