### PR TITLE
Introduce tenup-content-connect-update-relationships-order action

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     },
     "require-dev": {
         "10up/phpcs-composer": "^3.0",
+        "doctrine/instantiator": "^1.5",
         "phpcompatibility/php-compatibility": "dev-develop as 9.99.99",
         "phpunit/phpunit": "^9.0",
         "yoast/phpunit-polyfills": "^4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b3482e9d6718ba59c31b8a5b082b5cac",
+    "content-hash": "21852a8256c76bd7c3fff81555de353d",
     "packages": [
         {
             "name": "composer/installers",
@@ -290,29 +290,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.1.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.4"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.5.58"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -339,7 +340,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -355,7 +356,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T06:47:08+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/includes/Relationships/PostToPost.php
+++ b/includes/Relationships/PostToPost.php
@@ -236,6 +236,18 @@ class PostToPost extends Relationship {
 		/** @var \TenUp\ContentConnect\Tables\PostToPost $table */
 		$table = Plugin::instance()->get_table( 'p2p' );
 		$table->replace_bulk( $fields, $data );
+
+		/**
+		 * Fires after a relationship order has been updated
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param int    $object_id   ID of the object we're ordering on (post ID, or user ID for user-to-post).
+		 * @param int[]  $ordered_ids Ordered IDs of the related objects.
+		 * @param string $name        Relationship name.
+		 * @param string $type        Relationship type (post-to-post|post-to-user|user-to-post).
+		 */
+		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_ids, $this->name, 'post-to-post' );
 	}
 
 	/**

--- a/includes/Relationships/PostToUser.php
+++ b/includes/Relationships/PostToUser.php
@@ -216,7 +216,7 @@ class PostToUser extends Relationship {
 		/**
 		 * This action is documented in PostToPost.php
 		 */
-		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_ids, $this->name, 'post-to-user' );
+		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_user_ids, $this->name, 'post-to-user' );
 	}
 
 	/**

--- a/includes/Relationships/PostToUser.php
+++ b/includes/Relationships/PostToUser.php
@@ -212,6 +212,11 @@ class PostToUser extends Relationship {
 		/** @var \TenUp\ContentConnect\Tables\PostToUser $table */
 		$table = Plugin::instance()->get_table( 'p2u' );
 		$table->replace_bulk( $fields, $data );
+
+		/**
+		 * This action is documented in PostToPost.php
+		 */
+		do_action( 'tenup-content-connect-update-relationships-order', $object_id, $ordered_ids, $this->name, 'post-to-user' );
 	}
 
 	/**
@@ -252,6 +257,11 @@ class PostToUser extends Relationship {
 		/** @var \TenUp\ContentConnect\Tables\PostToUser $table */
 		$table = Plugin::instance()->get_table( 'p2u' );
 		$table->replace_bulk( $fields, $data );
+
+		/**
+		 * This action is documented in PostToPost.php
+		 */
+		do_action( 'tenup-content-connect-update-relationships-order', $user_id, $ordered_post_ids, $this->name, 'user-to-post' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required. Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion. All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Introduces a new `tenup-content-connect-update-relationships-order` action so extenders can run logic after relationship order is saved. It fires from `PostToPost::save_sort_data()` and both `PostToUser` sort methods, covering all three directions — `post-to-post`, `post-to-user`, and `user-to-post` — and passes the object ID, the ordered IDs, the relationship name, and the relationship type.

This is a rebase of #115 (@ocean90) onto the 2.0.0 line. Changes vs. the original PR:

- Resolved a trivial whitespace/alignment conflict against `develop` (kept `develop`'s formatting).
- Bumped the docblock `@since` from `1.7.0` to `2.0.0` (1.7.0 never shipped).
- Corrected the `@param` docs on the canonical block: `$object_id` also carries a **user ID** in the `user-to-post` fire, so the description is now type-agnostic.

Original authorship is preserved (`Author: Dominik Schilling`, plus a `Co-authored-by` trailer).

Closes https://github.com/10up/wp-content-connect/issues/114

### How to test the Change

1. Register a post-to-post and a post-to-user relationship with sortable order enabled.
2. Hook the new action:
   ```php
   add_action(
       'tenup-content-connect-update-relationships-order',
       function ( $object_id, $ordered_ids, $name, $type ) {
           error_log( "order updated: {$type} / {$name} / {$object_id} => " . implode( ',', $ordered_ids ) );
       },
       10,
       4
   );
   ```
3. Reorder related items on a post edit screen (post-to-post and post-to-user) and save.
4. Confirm the action fires once per save with the correct `$type` (`post-to-post`, `post-to-user`) and the ordered IDs matching the UI.
5. For `user-to-post`, trigger `PostToUser::save_user_to_post_order()` (API level) and confirm `$object_id` is the **user ID** and `$type` is `user-to-post`.

### Changelog Entry

> Added - `tenup-content-connect-update-relationships-order` action for developers.

### Credits

Props @ocean90

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
