### PR TITLE
Add changelog entry for `tenup-content-connect-update-relationships-order` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The changes below affect only code that referenced plugin **internals** that wer
 - WordPress JavaScript filter hooks `contentConnect.searchResultFilter`, `contentConnect.pickedItemFilter`, and `contentConnect.pickedItemPreviewComponent` for customizing the Block Editor UI, with relationship context awareness (props [@s3rgiosan](https://github.com/s3rgiosan) via [#104](https://github.com/10up/wp-content-connect/pull/104)).
 - WordPress 7.0 compatibility; set WordPress minimum supported version to 6.8 (props [@mphillips](https://github.com/mphillips) via [#120](https://github.com/10up/wp-content-connect/pull/120)).
 - WordPress Playground blueprint (`.github/blueprints/blueprint.json`) for a one-click, zero-install plugin demo (props [@s3rgiosan](https://github.com/s3rgiosan) via [#122](https://github.com/10up/wp-content-connect/pull/122)).
+- `tenup-content-connect-update-relationships-order` action for developers to run logic after relationship order is saved, firing for post-to-post, post-to-user, and user-to-post relationships (props [@ocean90](https://github.com/ocean90) via [#123](https://github.com/10up/wp-content-connect/pull/123)).
 
 ### Changed
 


### PR DESCRIPTION
### Description of the Change

Adds a missing changelog entry for the `tenup-content-connect-update-relationships-order` action introduced in #123. The entry is added under the `## [2.0.0]` → `### Added` section:

> `tenup-content-connect-update-relationships-order` action for developers to run logic after relationship order is saved, firing for post-to-post, post-to-user, and user-to-post relationships (props @ocean90 via #123).

### How to test the Change

1. Open `CHANGELOG.md`.
2. Confirm the entry appears under `## [2.0.0]` → `### Added`.

### Changelog Entry

> Added - `tenup-content-connect-update-relationships-order` action for developers.

### Credits

Props @ocean90

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added Critical Flows, Test Cases, and/or End-to-End Tests to cover my change.
- [ ] All new and existing tests pass.
